### PR TITLE
drop /ubuntu-25.10 branch from channels of snaps in dangerous model

### DIFF
--- a/ubuntu-classic-2510-amd64-dangerous.json
+++ b/ubuntu-classic-2510-amd64-dangerous.json
@@ -50,49 +50,49 @@
         {
             "name": "firmware-updater",
             "type": "app",
-            "default-channel": "1/edge/ubuntu-25.10",
+            "default-channel": "1/edge",
             "id": "EI0D1KHjP8XiwMZKqSjuh6W8zvcowUVP"
         },
         {
             "name": "desktop-security-center",
             "type": "app",
-            "default-channel": "1/edge/ubuntu-25.10",
+            "default-channel": "1/edge",
             "id": "FppXWunWzuRT2NUT9CwoBPNJNZBYOCk0"
         },
         {
             "name": "prompting-client",
             "type": "app",
-            "default-channel": "1/edge/ubuntu-25.10",
+            "default-channel": "1/edge",
             "id": "aoc5lfC8aUd2VL8VpvynUJJhGXp5K6Dj"
         },
         {
             "name": "snap-store",
             "type": "app",
-            "default-channel": "2/edge/ubuntu-25.10",
+            "default-channel": "2/edge",
             "id": "gjf3IPXoRiipCu9K0kVu52f0H56fIksg"
         },
         {
             "name": "gtk-common-themes",
             "type": "app",
-            "default-channel": "latest/edge/ubuntu-25.10",
+            "default-channel": "latest/edge",
             "id": "jZLfBRzf1cYlYysIjD2bwSzNtngY0qit"
         },
         {
             "name": "firefox",
             "type": "app",
-            "default-channel": "latest/edge/ubuntu-25.10",
+            "default-channel": "latest/edge",
             "id": "3wdHCAVyZEmYsCMFDE9qt92UV8rC8Wdk"
         },
         {
             "name": "gnome-42-2204",
             "type": "app",
-            "default-channel": "latest/edge/ubuntu-25.10",
+            "default-channel": "latest/edge",
             "id": "lATO8HzwVvrAPrlZRAWpfyrJKlAJrZS3"
         },
         {
             "name": "snapd-desktop-integration",
             "type": "app",
-            "default-channel": "latest/edge/ubuntu-25.10",
+            "default-channel": "latest/edge",
             "id": "IrwRHakqtzhFRHJOOPxKVPU0Kk7Erhcu"
         }
     ]


### PR DESCRIPTION
These branches don't generally exist and there's not really a reason to have them (we don't need no escape hatches here).