### PR TITLE
feat(GCE): Add ARM64 models for Core{24, 26}

### DIFF
--- a/cloud/gce/gce-core-24-arm64-dangerous.json
+++ b/cloud/gce/gce-core-24-arm64-dangerous.json
@@ -1,0 +1,45 @@
+{
+    "type": "model",
+    "series": "16",
+    "model": "gce-core-24-arm64-dangerous",
+    "architecture": "arm64",
+    "authority-id": "canonical",
+    "brand-id": "canonical",
+    "timestamp": "2025-08-25T14:45:00+00:00",
+    "base": "core24",
+    "grade": "dangerous",
+    "revision": "1",
+    "snaps": [
+        {
+            "name": "gce-gadget",
+            "type": "gadget",
+            "default-channel": "24/beta",
+            "id": "jQb6VXJonDq7VaBo66YPjE9SVoQV84hy"
+        },
+        {
+            "name": "gcp-kernel",
+            "type": "kernel",
+            "default-channel": "24/beta",
+            "id": "XCu2oFG8cSgq2ZWmdaMyvSZhrrUhy1yi"
+        },
+        {
+            "name": "core24",
+            "type": "base",
+            "default-channel": "latest/beta",
+            "id": "dwTAh7MZZ01zyriOZErqd1JynQLiOGvM"
+        },
+        {
+            "name": "snapd",
+            "type": "snapd",
+            "default-channel": "latest/beta",
+            "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"
+        },
+        {
+            "name": "console-conf",
+            "type": "app",
+            "default-channel": "24/beta",
+            "id": "ASctKBEHzVt3f1pbZLoekCvcigRjtuqw",
+            "presence": "optional"
+        }
+    ]
+}

--- a/cloud/gce/gce-core-24-arm64.json
+++ b/cloud/gce/gce-core-24-arm64.json
@@ -1,0 +1,45 @@
+{
+    "type": "model",
+    "series": "16",
+    "model": "gce-core-24-arm64",
+    "architecture": "arm64",
+    "authority-id": "canonical",
+    "brand-id": "canonical",
+    "timestamp": "2025-08-25T14:45:00+00:00",
+    "base": "core24",
+    "grade": "signed",
+    "revision": "1",
+    "snaps": [
+        {
+            "name": "gce-gadget",
+            "type": "gadget",
+            "default-channel": "24/stable",
+            "id": "jQb6VXJonDq7VaBo66YPjE9SVoQV84hy"
+        },
+        {
+            "name": "gcp-kernel",
+            "type": "kernel",
+            "default-channel": "24/stable",
+            "id": "XCu2oFG8cSgq2ZWmdaMyvSZhrrUhy1yi"
+        },
+        {
+            "name": "core24",
+            "type": "base",
+            "default-channel": "latest/stable",
+            "id": "dwTAh7MZZ01zyriOZErqd1JynQLiOGvM"
+        },
+        {
+            "name": "snapd",
+            "type": "snapd",
+            "default-channel": "latest/stable",
+            "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"
+        },
+        {
+            "name": "console-conf",
+            "type": "app",
+            "default-channel": "24/stable",
+            "id": "ASctKBEHzVt3f1pbZLoekCvcigRjtuqw",
+            "presence": "optional"
+        }
+    ]
+}

--- a/cloud/gce/gce-core-26-arm64-dangerous.json
+++ b/cloud/gce/gce-core-26-arm64-dangerous.json
@@ -1,0 +1,45 @@
+{
+    "type": "model",
+    "series": "16",
+    "model": "gce-core-26-arm64-dangerous",
+    "architecture": "arm64",
+    "authority-id": "canonical",
+    "brand-id": "canonical",
+    "timestamp": "2025-08-25T14:45:00+00:00",
+    "base": "core26",
+    "grade": "dangerous",
+    "revision": "1",
+    "snaps": [
+        {
+            "name": "gce-gadget",
+            "type": "gadget",
+            "default-channel": "26/beta",
+            "id": "jQb6VXJonDq7VaBo66YPjE9SVoQV84hy"
+        },
+        {
+            "name": "gcp-kernel",
+            "type": "kernel",
+            "default-channel": "26/beta",
+            "id": "XCu2oFG8cSgq2ZWmdaMyvSZhrrUhy1yi"
+        },
+        {
+            "name": "core26",
+            "type": "base",
+            "default-channel": "latest/beta",
+            "id": "cUqM61hRuZAJYmIS898Ux66VY61gBbZf"
+        },
+        {
+            "name": "snapd",
+            "type": "snapd",
+            "default-channel": "latest/beta",
+            "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"
+        },
+        {
+            "name": "console-conf",
+            "type": "app",
+            "default-channel": "26/beta",
+            "id": "ASctKBEHzVt3f1pbZLoekCvcigRjtuqw",
+            "presence": "optional"
+        }
+    ]
+}

--- a/cloud/gce/gce-core-26-arm64.json
+++ b/cloud/gce/gce-core-26-arm64.json
@@ -1,0 +1,45 @@
+{
+    "type": "model",
+    "series": "16",
+    "model": "gce-core-26-arm64",
+    "architecture": "arm64",
+    "authority-id": "canonical",
+    "brand-id": "canonical",
+    "timestamp": "2025-08-25T14:45:00+00:00",
+    "base": "core26",
+    "grade": "signed",
+    "revision": "1",
+    "snaps": [
+        {
+            "name": "gce-gadget",
+            "type": "gadget",
+            "default-channel": "26/stable",
+            "id": "jQb6VXJonDq7VaBo66YPjE9SVoQV84hy"
+        },
+        {
+            "name": "gcp-kernel",
+            "type": "kernel",
+            "default-channel": "26/stable",
+            "id": "XCu2oFG8cSgq2ZWmdaMyvSZhrrUhy1yi"
+        },
+        {
+            "name": "core26",
+            "type": "base",
+            "default-channel": "latest/stable",
+            "id": "cUqM61hRuZAJYmIS898Ux66VY61gBbZf"
+        },
+        {
+            "name": "snapd",
+            "type": "snapd",
+            "default-channel": "latest/stable",
+            "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"
+        },
+        {
+            "name": "console-conf",
+            "type": "app",
+            "default-channel": "26/stable",
+            "id": "ASctKBEHzVt3f1pbZLoekCvcigRjtuqw",
+            "presence": "optional"
+        }
+    ]
+}


### PR DESCRIPTION
We already have ARM64 builds for the `gce-gadget` (and `gcp-kernel`/`core{24, 26}`/`snapd` of course) so let's add ARM64 models so we at east have the ability later to create ARM64 images if needed.