### PR TITLE
Add UC24 models for tegra jetson

### DIFF
--- a/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson-beta.json
+++ b/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson-beta.json
@@ -1,0 +1,44 @@
+{
+    "type": "model",
+    "series": "16",
+    "model": "ubuntu-core-24-tegra-jetson",
+    "architecture": "arm64",
+    "authority-id": "canonical",
+    "brand-id": "canonical",
+    "timestamp": "2026-07-10T09:28:47+00:00",
+    "base": "core24",
+    "grade": "signed",
+    "snaps": [
+        {
+            "name": "tegra",
+            "type": "gadget",
+            "default-channel": "24-jetson/beta",
+            "id": "9pjCtYlNoT9Fx6RiHMhhBoIG6ZYXBvJc"
+        },
+        {
+            "name": "tegra-kernel",
+            "type": "kernel",
+            "default-channel": "24-jetson/beta",
+            "id": "Rjyoy6Zhe9mlkBQqmVzaUdPB2TblFSwV"
+        },
+        {
+            "name": "core24",
+            "type": "base",
+            "default-channel": "latest/beta",
+            "id": "dwTAh7MZZ01zyriOZErqd1JynQLiOGvM"
+        },
+        {
+            "name": "snapd",
+            "type": "snapd",
+            "default-channel": "latest/beta",
+            "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"
+        },
+        {
+            "default-channel": "24/beta",
+            "id": "ASctKBEHzVt3f1pbZLoekCvcigRjtuqw",
+            "name": "console-conf",
+            "presence": "optional",
+            "type": "app"
+        }
+    ]
+}

--- a/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson-beta.model
+++ b/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson-beta.model
@@ -1,0 +1,48 @@
+type: model
+authority-id: canonical
+series: 16
+brand-id: canonical
+model: ubuntu-core-24-tegra-jetson
+architecture: arm64
+base: core24
+grade: signed
+snaps:
+  -
+    default-channel: 24-jetson/beta
+    id: 9pjCtYlNoT9Fx6RiHMhhBoIG6ZYXBvJc
+    name: tegra
+    type: gadget
+  -
+    default-channel: 24-jetson/beta
+    id: Rjyoy6Zhe9mlkBQqmVzaUdPB2TblFSwV
+    name: tegra-kernel
+    type: kernel
+  -
+    default-channel: latest/beta
+    id: dwTAh7MZZ01zyriOZErqd1JynQLiOGvM
+    name: core24
+    type: base
+  -
+    default-channel: latest/beta
+    id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
+    name: snapd
+    type: snapd
+  -
+    default-channel: 24/beta
+    id: ASctKBEHzVt3f1pbZLoekCvcigRjtuqw
+    name: console-conf
+    presence: optional
+    type: app
+timestamp: 2026-07-10T09:28:47+00:00
+sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
+
+AcLBXAQAAQoABgUCalEuWwAKCRDgT5vottzAEtvnD/9PLWstQYPqdGPMo5R7Gzd1n6Ahz8N2gu4Y
+TXi0WSHj2KPdCDJkxuyKNb4N1+gu+tWRsFpoN1Cjgv5hxnQrEvNnOXlkvVy9MCpGp2t3jKPVqfs+
+ZJFCiFrEi60iPeWQGYjvS9eFwZvvGZ7i4LJPXZJaH9FpfEhwWXgapYEuOOdtmkwKgXU1DVDhNyj9
+UC2GL8bmYZi5y8x4fokjRX6zssl/a1i9CHQPDgqvln/YbXBx6Fyv6dGBihaC5WroaOJ1FvQFZbny
+5eOB/KnX5aSh5YqrS/yCqTUVUEKtpD4MA5WEJax+YEeDBGusj8d8nfyCkRnRCEeA/5C46YfA9D3x
+khOgIT3epmbwZ0l2gNj0vJ0Wk+GKks/h/7prWRVHyZj4zPQerrmv4St/EjQWI729yhIDw2I7CnUo
+L0g4XSpRUGeT5PAa8bAaO6AcuhWp7Ay7zWMQYIn1OUtFaq3hOVZVizb8bB/RDejeqXap+pnmr+31
+E6xjjev1uVxNFpf7JCd9UpwqbSpRcExq66UIzRBX4kefbfrD0s78zoQx3oyJ+6+eaUy1oNkxjVw3
+/JIm3p+WAHVlLGIc1ddzas/e8cg/I1IoVwSeA3VxFi7W67uT2CPiJ35SMhfrGkdI0gLFGOzIip/M
+arnlMXjTxuwvqjiexwOP+ucVM2XrUWVJL2OVtxY8BA==

--- a/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson-candidate.json
+++ b/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson-candidate.json
@@ -1,0 +1,44 @@
+{
+    "type": "model",
+    "series": "16",
+    "model": "ubuntu-core-24-tegra-jetson",
+    "architecture": "arm64",
+    "authority-id": "canonical",
+    "brand-id": "canonical",
+    "timestamp": "2026-07-10T09:28:47+00:00",
+    "base": "core24",
+    "grade": "signed",
+    "snaps": [
+        {
+            "name": "tegra",
+            "type": "gadget",
+            "default-channel": "24-jetson/candidate",
+            "id": "9pjCtYlNoT9Fx6RiHMhhBoIG6ZYXBvJc"
+        },
+        {
+            "name": "tegra-kernel",
+            "type": "kernel",
+            "default-channel": "24-jetson/candidate",
+            "id": "Rjyoy6Zhe9mlkBQqmVzaUdPB2TblFSwV"
+        },
+        {
+            "name": "core24",
+            "type": "base",
+            "default-channel": "latest/candidate",
+            "id": "dwTAh7MZZ01zyriOZErqd1JynQLiOGvM"
+        },
+        {
+            "name": "snapd",
+            "type": "snapd",
+            "default-channel": "latest/candidate",
+            "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"
+        },
+        {
+            "default-channel": "24/candidate",
+            "id": "ASctKBEHzVt3f1pbZLoekCvcigRjtuqw",
+            "name": "console-conf",
+            "presence": "optional",
+            "type": "app"
+        }
+    ]
+}

--- a/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson-candidate.model
+++ b/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson-candidate.model
@@ -1,0 +1,48 @@
+type: model
+authority-id: canonical
+series: 16
+brand-id: canonical
+model: ubuntu-core-24-tegra-jetson
+architecture: arm64
+base: core24
+grade: signed
+snaps:
+  -
+    default-channel: 24-jetson/candidate
+    id: 9pjCtYlNoT9Fx6RiHMhhBoIG6ZYXBvJc
+    name: tegra
+    type: gadget
+  -
+    default-channel: 24-jetson/candidate
+    id: Rjyoy6Zhe9mlkBQqmVzaUdPB2TblFSwV
+    name: tegra-kernel
+    type: kernel
+  -
+    default-channel: latest/candidate
+    id: dwTAh7MZZ01zyriOZErqd1JynQLiOGvM
+    name: core24
+    type: base
+  -
+    default-channel: latest/candidate
+    id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
+    name: snapd
+    type: snapd
+  -
+    default-channel: 24/candidate
+    id: ASctKBEHzVt3f1pbZLoekCvcigRjtuqw
+    name: console-conf
+    presence: optional
+    type: app
+timestamp: 2026-07-10T09:28:47+00:00
+sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
+
+AcLBXAQAAQoABgUCalEuWwAKCRDgT5vottzAEpaZEAC5qOYW/+ABdQQXQ5Xtexr8R5U6TJwy71yC
+QBG+gTug60SWBoMtlJNquHL3ONri6xGDIyyphzs4hYGuT8TMJHAyw/8BKmYnt1tvcrTgQ+hs3T0D
+0xmt953c5jXC8QWsmiGIfC0BcB55zd8A2u1nOYjDfbjlVjVYHlKk86+m7Z5xqAt47+VraBXaZJbJ
+n3hdsKqw1NWEFjbupSxLQmNe1oN+9k/tLgDzZoAW1oTDM88zfWJSqF+q9aGbkcPcFIEGvUQnJ1i1
+KQypYBvIwKHAdfBLjrHDtLe0Ewt6RWK8jxdzQ8gelpLcI7gbSqwpYxjsCx746hGEW9Uf1BdJ8KC8
+LA9rSd20ZZxntECrtnLhAeXfS/w/bU0igPK7aYin9BpXT0g3JaybqIXYmfBgsfuQhbZIdLDOB0YR
+nCdXLlrZXbHiTA3C3mQjgBgU6Fpwqplol0oyfgVRShhNsJ1C1f8aBpDslxNnI4uL2cXDwAMOhznl
+WK0iA/18NZeerB0/ENi1/v9qA71NhUzAF8LS57Vc818p9LpnhD/Q9mfmggCOj7GYJzoBGCuoVmVR
+ZOwXknxPkl89ngywmj201Kkv5eVaGRxgwSWlpJSnDkudbV4tHA1OHCPc/0Ml09KEai7QA1GOGVfA
+EQHBV5FW1xx6YpJD1m41+t8NmAZceHeisgKhIDFFpg==

--- a/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson-dangerous-beta.json
+++ b/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson-dangerous-beta.json
@@ -1,0 +1,44 @@
+{
+    "type": "model",
+    "series": "16",
+    "model": "ubuntu-core-24-tegra-jetson",
+    "architecture": "arm64",
+    "authority-id": "canonical",
+    "brand-id": "canonical",
+    "timestamp": "2026-07-10T09:28:47+00:00",
+    "base": "core24",
+    "grade": "dangerous",
+    "snaps": [
+        {
+            "name": "tegra",
+            "type": "gadget",
+            "default-channel": "24-jetson/beta",
+            "id": "9pjCtYlNoT9Fx6RiHMhhBoIG6ZYXBvJc"
+        },
+        {
+            "name": "tegra-kernel",
+            "type": "kernel",
+            "default-channel": "24-jetson/beta",
+            "id": "Rjyoy6Zhe9mlkBQqmVzaUdPB2TblFSwV"
+        },
+        {
+            "name": "core24",
+            "type": "base",
+            "default-channel": "latest/beta",
+            "id": "dwTAh7MZZ01zyriOZErqd1JynQLiOGvM"
+        },
+        {
+            "name": "snapd",
+            "type": "snapd",
+            "default-channel": "latest/beta",
+            "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"
+        },
+        {
+            "default-channel": "24/beta",
+            "id": "ASctKBEHzVt3f1pbZLoekCvcigRjtuqw",
+            "name": "console-conf",
+            "presence": "optional",
+            "type": "app"
+        }
+    ]
+}

--- a/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson-dangerous-beta.model
+++ b/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson-dangerous-beta.model
@@ -1,0 +1,48 @@
+type: model
+authority-id: canonical
+series: 16
+brand-id: canonical
+model: ubuntu-core-24-tegra-jetson
+architecture: arm64
+base: core24
+grade: dangerous
+snaps:
+  -
+    default-channel: 24-jetson/beta
+    id: 9pjCtYlNoT9Fx6RiHMhhBoIG6ZYXBvJc
+    name: tegra
+    type: gadget
+  -
+    default-channel: 24-jetson/beta
+    id: Rjyoy6Zhe9mlkBQqmVzaUdPB2TblFSwV
+    name: tegra-kernel
+    type: kernel
+  -
+    default-channel: latest/beta
+    id: dwTAh7MZZ01zyriOZErqd1JynQLiOGvM
+    name: core24
+    type: base
+  -
+    default-channel: latest/beta
+    id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
+    name: snapd
+    type: snapd
+  -
+    default-channel: 24/beta
+    id: ASctKBEHzVt3f1pbZLoekCvcigRjtuqw
+    name: console-conf
+    presence: optional
+    type: app
+timestamp: 2026-07-10T09:28:47+00:00
+sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
+
+AcLBXAQAAQoABgUCalEuWwAKCRDgT5vottzAEnLDD/9OFvjG7k1Nl0RvPv9DNjjeJmzKCY/JUFVW
+cKO0PTVM39uEQL5PQLCTXCOhWXA3gZgqko0ErIkMg+lfPWzrf9l5vfvOUeZvtucalArc0dO+ZeTm
+5kDfGBJ/SuuG3COzbyFv+g/R5AUFmo0GYE9xoY7CiibaN6aJf3lWCdj4/J/8JnkuIL4ZD4YtDPNU
+64aWcPLQX3bKoRhUl8hJke4CQ9BSRqJRZPzklYaRk7a/x98wPjZeboZWvTu1pZLBaG+FUebLQSII
+ZziWquQvrj1GmHFagpbwSOvwl1iH1RCq5Bh08dFRI+Inwl3pigkltF9gFp8ybmTNi+mCMe1tqwfK
+hkKmowa/9My9Ny7+wMtBoF7sBQord+pIHduq+05QN6cyKsSJy5IgownlxKQzZETjiqYSQditbTMT
+Opa560GvAeklFMut/RoTRB3mcT+qYK3SImDJAJvsS4k6FUh7lL2kz6HN+NiL40yCj/OrsuidJ/n0
+1A5OgxIv2t33ffj/YpTAnAfXvakVL7FVyiziFRBWYfM+i1RbJ4Jjqb5eKFgNMdVQfl5hn1YzWNI/
+P/KwXW5Qi7E/yNxyuVoiJvZdVSgTOUwgIq4XI/K1e3pKnt2I49W18hDLYfEBq0Ct+qbO5vmR1dpf
+D6isnJNAcA6Z6p7haP/Q2BREIsRLEjO9xK4Lx2DoSg==

--- a/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson-dangerous-candidate.json
+++ b/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson-dangerous-candidate.json
@@ -1,0 +1,44 @@
+{
+    "type": "model",
+    "series": "16",
+    "model": "ubuntu-core-24-tegra-jetson",
+    "architecture": "arm64",
+    "authority-id": "canonical",
+    "brand-id": "canonical",
+    "timestamp": "2026-07-10T09:28:47+00:00",
+    "base": "core24",
+    "grade": "dangerous",
+    "snaps": [
+        {
+            "name": "tegra",
+            "type": "gadget",
+            "default-channel": "24-jetson/candidate",
+            "id": "9pjCtYlNoT9Fx6RiHMhhBoIG6ZYXBvJc"
+        },
+        {
+            "name": "tegra-kernel",
+            "type": "kernel",
+            "default-channel": "24-jetson/candidate",
+            "id": "Rjyoy6Zhe9mlkBQqmVzaUdPB2TblFSwV"
+        },
+        {
+            "name": "core24",
+            "type": "base",
+            "default-channel": "latest/candidate",
+            "id": "dwTAh7MZZ01zyriOZErqd1JynQLiOGvM"
+        },
+        {
+            "name": "snapd",
+            "type": "snapd",
+            "default-channel": "latest/candidate",
+            "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"
+        },
+        {
+            "default-channel": "24/candidate",
+            "id": "ASctKBEHzVt3f1pbZLoekCvcigRjtuqw",
+            "name": "console-conf",
+            "presence": "optional",
+            "type": "app"
+        }
+    ]
+}

--- a/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson-dangerous-candidate.model
+++ b/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson-dangerous-candidate.model
@@ -1,0 +1,48 @@
+type: model
+authority-id: canonical
+series: 16
+brand-id: canonical
+model: ubuntu-core-24-tegra-jetson
+architecture: arm64
+base: core24
+grade: dangerous
+snaps:
+  -
+    default-channel: 24-jetson/candidate
+    id: 9pjCtYlNoT9Fx6RiHMhhBoIG6ZYXBvJc
+    name: tegra
+    type: gadget
+  -
+    default-channel: 24-jetson/candidate
+    id: Rjyoy6Zhe9mlkBQqmVzaUdPB2TblFSwV
+    name: tegra-kernel
+    type: kernel
+  -
+    default-channel: latest/candidate
+    id: dwTAh7MZZ01zyriOZErqd1JynQLiOGvM
+    name: core24
+    type: base
+  -
+    default-channel: latest/candidate
+    id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
+    name: snapd
+    type: snapd
+  -
+    default-channel: 24/candidate
+    id: ASctKBEHzVt3f1pbZLoekCvcigRjtuqw
+    name: console-conf
+    presence: optional
+    type: app
+timestamp: 2026-07-10T09:28:47+00:00
+sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
+
+AcLBXAQAAQoABgUCalEuWwAKCRDgT5vottzAEsyaEACzM9fzLQK74a4crOzzCJhxndcjh8TODnh/
+ymjjym5E8T6QSXnfnA5TCvdeqpokyQc3JjkXu5RKN+toYGivqr2lahnJBk1wjYfThij5//eelQ0z
+M7z1Zlba/jJEChTbEQZ2mF6JOh5wcJueHbc0m+bn8zyDtQtQOF+xOymJtqGQy+G7oBhBZgXlM8Au
+jQDbyHCxzgS8AGcgPJumWfiLlQ4+BLDugeMJd50MPqIbsxLZl1ooF1Ugftun+6PONexwUieGXxlN
+JMxH087kNcX2o1crqeBgEsDKvVAmkUDOtUmnuhyC1DWsFosx3sKuRUayb5mDNRDqFng1j9aElPB8
+uzDEgWD3AEUK42R2JabOyvspiF5GIFcedHdrbMAbbXLS1oq6/vYFXlKhiSQW/gzYNEv/jv8KthuT
+GZAhV/gArrZv3RMwx2/372VmiZuGnhZlwYqE0trYAwHufxyMNGHbLImvLDo5/5XqIdbRP5Hze9UE
+JVDcZddz4yRLSzqr/sJOafRMce8lIunOEc8wIex+4TXcy1FWQY+O2DHlyfPAuHQit0wSsUrSo7vY
+1nppM9CGFBch0BSxTLobbqOBaJ333A2NSXXnduPgJdSchFNWPUVuvAdnZO5QInXNX0b9vMRaYCa3
+BH7LDua8X8l6OoZKviAfIM+z7YheKBgCedHOiqHVzg==

--- a/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson-dangerous-edge.json
+++ b/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson-dangerous-edge.json
@@ -1,0 +1,44 @@
+{
+    "type": "model",
+    "series": "16",
+    "model": "ubuntu-core-24-tegra-jetson",
+    "architecture": "arm64",
+    "authority-id": "canonical",
+    "brand-id": "canonical",
+    "timestamp": "2026-07-10T09:28:47+00:00",
+    "base": "core24",
+    "grade": "dangerous",
+    "snaps": [
+        {
+            "name": "tegra",
+            "type": "gadget",
+            "default-channel": "24-jetson/edge",
+            "id": "9pjCtYlNoT9Fx6RiHMhhBoIG6ZYXBvJc"
+        },
+        {
+            "name": "tegra-kernel",
+            "type": "kernel",
+            "default-channel": "24-jetson/edge",
+            "id": "Rjyoy6Zhe9mlkBQqmVzaUdPB2TblFSwV"
+        },
+        {
+            "name": "core24",
+            "type": "base",
+            "default-channel": "latest/edge",
+            "id": "dwTAh7MZZ01zyriOZErqd1JynQLiOGvM"
+        },
+        {
+            "name": "snapd",
+            "type": "snapd",
+            "default-channel": "latest/edge",
+            "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"
+        },
+        {
+            "default-channel": "24/edge",
+            "id": "ASctKBEHzVt3f1pbZLoekCvcigRjtuqw",
+            "name": "console-conf",
+            "presence": "optional",
+            "type": "app"
+        }
+    ]
+}

--- a/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson-dangerous-edge.model
+++ b/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson-dangerous-edge.model
@@ -1,0 +1,48 @@
+type: model
+authority-id: canonical
+series: 16
+brand-id: canonical
+model: ubuntu-core-24-tegra-jetson
+architecture: arm64
+base: core24
+grade: dangerous
+snaps:
+  -
+    default-channel: 24-jetson/edge
+    id: 9pjCtYlNoT9Fx6RiHMhhBoIG6ZYXBvJc
+    name: tegra
+    type: gadget
+  -
+    default-channel: 24-jetson/edge
+    id: Rjyoy6Zhe9mlkBQqmVzaUdPB2TblFSwV
+    name: tegra-kernel
+    type: kernel
+  -
+    default-channel: latest/edge
+    id: dwTAh7MZZ01zyriOZErqd1JynQLiOGvM
+    name: core24
+    type: base
+  -
+    default-channel: latest/edge
+    id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
+    name: snapd
+    type: snapd
+  -
+    default-channel: 24/edge
+    id: ASctKBEHzVt3f1pbZLoekCvcigRjtuqw
+    name: console-conf
+    presence: optional
+    type: app
+timestamp: 2026-07-10T09:28:47+00:00
+sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
+
+AcLBXAQAAQoABgUCalEuXAAKCRDgT5vottzAEv7VEACLnOfsppotPpitFRS2y3YyK1sLIobbTbe/
+7HXZut/U2Bd95qqxwGoMPce/WBbh+Kel6gQfcXNHpRgWE94bGJ2/SqkJgSCbu1O6UIp4ppWcxfKe
+aJtr1bazjxDWIs0NEvAykPHfV44cBssjlDyVF0b0zyoJzPaPZD+ft73VqA54P7JuX+8ni/IUdDCD
+jCinxZh0RObD9xqcqcYbez55cMLyHuO6DZOHJMeFd3NIYqSvRnblt1OJBjJ+gcPDohhhe5JasyDU
+IOny4wPTMWM86wH6wqFqyRQ+pLjW0IBrK+ALdbZVzvEsVrkDlywT1OPcBqAnY0dgkUw+0lZEMacq
+/YQscc+8uQ5HSdrnHvbpPwwMP5FQEVx+Ozrt7+2gcHPJvCOY5fMYC5BDH7BYpYnBG+Cg/P78iYYY
+Fq+kIwlo7bMPUOsiRJJY4jaZAHtbTw+oPlkztmKP4IuNJBARntXydgYhl4qTHLsBNE7XfiEgiY3p
+4RuzxzKvJ8L0thUPtEadULeYlvrTisKQr7uAvAE9LLpzgS0os6NuVk7/jPF3rKjRCSI2Kp/Ik/OC
+TTeV8SYeVnT0zAx5MBNCmKqZp2MwvZqenF+aHwvZJNPrAVt6ACWxqhX79YJse9E/a7C8kv2A3cm8
+3ke673lOdf+Lho39LqzFqSfbUBnpaiKIiphzJmPMhQ==

--- a/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson-dangerous.json
+++ b/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson-dangerous.json
@@ -1,0 +1,44 @@
+{
+    "type": "model",
+    "series": "16",
+    "model": "ubuntu-core-24-tegra-jetson",
+    "architecture": "arm64",
+    "authority-id": "canonical",
+    "brand-id": "canonical",
+    "timestamp": "2026-07-10T09:28:47+00:00",
+    "base": "core24",
+    "grade": "dangerous",
+    "snaps": [
+        {
+            "name": "tegra",
+            "type": "gadget",
+            "default-channel": "24-jetson/stable",
+            "id": "9pjCtYlNoT9Fx6RiHMhhBoIG6ZYXBvJc"
+        },
+        {
+            "name": "tegra-kernel",
+            "type": "kernel",
+            "default-channel": "24-jetson/stable",
+            "id": "Rjyoy6Zhe9mlkBQqmVzaUdPB2TblFSwV"
+        },
+        {
+            "name": "core24",
+            "type": "base",
+            "default-channel": "latest/stable",
+            "id": "dwTAh7MZZ01zyriOZErqd1JynQLiOGvM"
+        },
+        {
+            "name": "snapd",
+            "type": "snapd",
+            "default-channel": "latest/stable",
+            "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"
+        },
+        {
+            "default-channel": "24/stable",
+            "id": "ASctKBEHzVt3f1pbZLoekCvcigRjtuqw",
+            "name": "console-conf",
+            "presence": "optional",
+            "type": "app"
+        }
+    ]
+}

--- a/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson-dangerous.model
+++ b/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson-dangerous.model
@@ -1,0 +1,48 @@
+type: model
+authority-id: canonical
+series: 16
+brand-id: canonical
+model: ubuntu-core-24-tegra-jetson
+architecture: arm64
+base: core24
+grade: dangerous
+snaps:
+  -
+    default-channel: 24-jetson/stable
+    id: 9pjCtYlNoT9Fx6RiHMhhBoIG6ZYXBvJc
+    name: tegra
+    type: gadget
+  -
+    default-channel: 24-jetson/stable
+    id: Rjyoy6Zhe9mlkBQqmVzaUdPB2TblFSwV
+    name: tegra-kernel
+    type: kernel
+  -
+    default-channel: latest/stable
+    id: dwTAh7MZZ01zyriOZErqd1JynQLiOGvM
+    name: core24
+    type: base
+  -
+    default-channel: latest/stable
+    id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
+    name: snapd
+    type: snapd
+  -
+    default-channel: 24/stable
+    id: ASctKBEHzVt3f1pbZLoekCvcigRjtuqw
+    name: console-conf
+    presence: optional
+    type: app
+timestamp: 2026-07-10T09:28:47+00:00
+sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
+
+AcLBXAQAAQoABgUCalEuXAAKCRDgT5vottzAEhx/D/9X+wmeSeW7nDHK/t3exglpTBhpxBknTxSk
+CQoCwKS7UiJHhwTl8bB+wN4n5SmF/5Nrm4zjYAu1J+sSW1YHGjMGlDjfp+iT9OXrqsCqbs0CnyuP
+bixLJjNngWhA5ddYeD0jnoJmIjSiVHoqSpl6f9i/McDGSj9qM4pB1spxm9+IKtmkFW5hEdOJ+Dto
+i0jXU2qw6iJz3Nt8EoWx3d4arSmjDMP7RFoophu3861iKxOsi3pN/XFs5IXsMZlLFpFOMZ20ay+l
+oqbP8b75AdMt4dIsBkTKBcrQHHRf3DHKfIO9J3DJQKV3LZ8cyS2YTXoeUcsI7mbwzj1rbj8J/Rvb
+G6wMvBwIfl1mvRG3LhS5IV7+eSrCL/kinsDEqKk23j/AZWq2BR4948QMVUICWjj0AtAVd/85MBP9
+CITwu67COK+qRGV3IgVlG2fOrM83ZaUC65fWCfeUDIjHPFq6fLUA3+bXpZRhEzU57eyGol6UMREA
+qAABSqCu2zC50Y4d1/owgj2hiC0X7BMt4JVzQ9DLN+fI4+Qk2/8HiLED/LlWhJ0cpuxqZx1dqnMJ
+qpeJAXmusCSxdT/XpZnN0PRL7jU99mWZwB7vBfGPQ9mqA825iGcm76/KhO29AKreVYN3uRU87Fkg
+3fWQf/JTsKS9duuA2vcxvOMiaBZaCiYLSufb1yF+Nw==

--- a/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson-edge.json
+++ b/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson-edge.json
@@ -1,0 +1,44 @@
+{
+    "type": "model",
+    "series": "16",
+    "model": "ubuntu-core-24-tegra-jetson",
+    "architecture": "arm64",
+    "authority-id": "canonical",
+    "brand-id": "canonical",
+    "timestamp": "2026-07-10T09:28:47+00:00",
+    "base": "core24",
+    "grade": "signed",
+    "snaps": [
+        {
+            "name": "tegra",
+            "type": "gadget",
+            "default-channel": "24-jetson/edge",
+            "id": "9pjCtYlNoT9Fx6RiHMhhBoIG6ZYXBvJc"
+        },
+        {
+            "name": "tegra-kernel",
+            "type": "kernel",
+            "default-channel": "24-jetson/edge",
+            "id": "Rjyoy6Zhe9mlkBQqmVzaUdPB2TblFSwV"
+        },
+        {
+            "name": "core24",
+            "type": "base",
+            "default-channel": "latest/edge",
+            "id": "dwTAh7MZZ01zyriOZErqd1JynQLiOGvM"
+        },
+        {
+            "name": "snapd",
+            "type": "snapd",
+            "default-channel": "latest/edge",
+            "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"
+        },
+        {
+            "default-channel": "24/edge",
+            "id": "ASctKBEHzVt3f1pbZLoekCvcigRjtuqw",
+            "name": "console-conf",
+            "presence": "optional",
+            "type": "app"
+        }
+    ]
+}

--- a/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson-edge.model
+++ b/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson-edge.model
@@ -1,0 +1,48 @@
+type: model
+authority-id: canonical
+series: 16
+brand-id: canonical
+model: ubuntu-core-24-tegra-jetson
+architecture: arm64
+base: core24
+grade: signed
+snaps:
+  -
+    default-channel: 24-jetson/edge
+    id: 9pjCtYlNoT9Fx6RiHMhhBoIG6ZYXBvJc
+    name: tegra
+    type: gadget
+  -
+    default-channel: 24-jetson/edge
+    id: Rjyoy6Zhe9mlkBQqmVzaUdPB2TblFSwV
+    name: tegra-kernel
+    type: kernel
+  -
+    default-channel: latest/edge
+    id: dwTAh7MZZ01zyriOZErqd1JynQLiOGvM
+    name: core24
+    type: base
+  -
+    default-channel: latest/edge
+    id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
+    name: snapd
+    type: snapd
+  -
+    default-channel: 24/edge
+    id: ASctKBEHzVt3f1pbZLoekCvcigRjtuqw
+    name: console-conf
+    presence: optional
+    type: app
+timestamp: 2026-07-10T09:28:47+00:00
+sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
+
+AcLBXAQAAQoABgUCalEuXAAKCRDgT5vottzAEoH+D/9Usm1CPKl7sL2JLQS3B1RnvLkZMOyOf+1D
+68g+8fI1Zwj3f6sLYNGOW15/5tyPO/dqxW/4U1Ht/xWW8ZNr88JGPfenw/T8fTba+UFYXrL/O7iy
+B160398fxtKs2l8rdXmRyZOMzgbm1lX7eYuSKx6tLYE4+p5b75h7Agk81yiXvAXYVmwkDETNip/l
+OIOkExhcoKoLSaFIzW+HL//uc5Uk3/oFvk2jwVQwvI4smztyBFzwoXpuTUhuIqFds1vcy7MyWmw0
+e5YihkeiWZd7QawQQ+U6QQ5ZdnvqZ6qTuJP3HDPPrvUDwUOhAhctR35xAjT2JYdR7egKg6m8VP6M
+lKWAb7Waz+6EAP451xSfr0dSJYfffOePDESTOldo8+nznbitbqZurzs8l7JM5cwL2I3IoxZDM2e7
+qQQsQVcWbDlA6FkWaS/QxPkIKTLhlRnadBUmIRLfPFGDzvSQDbK8jbPuUAnv7XK9/d2CQ6PzS1CJ
+yTVyQ5EkyP0iKwm2R3CG6dSp2RXbUdxLATz4KQ3NJR/7P4XQdyVqXjCaQMdC3DDoyDxGC/Aa7xoM
+FLLCTPLvmizElh7Gc45WgB13e/RbGkl0avdecQra7Z5znkrwQD/F2nzpqc3O2V954O8xWjptvDsQ
+pd9ePsnUxOBbxFt82bRj0nangPkPzTrxin/BbBudUw==

--- a/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson.json
+++ b/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson.json
@@ -1,0 +1,44 @@
+{
+    "type": "model",
+    "series": "16",
+    "model": "ubuntu-core-24-tegra-jetson",
+    "architecture": "arm64",
+    "authority-id": "canonical",
+    "brand-id": "canonical",
+    "timestamp": "2026-07-10T09:28:47+00:00",
+    "base": "core24",
+    "grade": "signed",
+    "snaps": [
+        {
+            "name": "tegra",
+            "type": "gadget",
+            "default-channel": "24-jetson/stable",
+            "id": "9pjCtYlNoT9Fx6RiHMhhBoIG6ZYXBvJc"
+        },
+        {
+            "name": "tegra-kernel",
+            "type": "kernel",
+            "default-channel": "24-jetson/stable",
+            "id": "Rjyoy6Zhe9mlkBQqmVzaUdPB2TblFSwV"
+        },
+        {
+            "name": "core24",
+            "type": "base",
+            "default-channel": "latest/stable",
+            "id": "dwTAh7MZZ01zyriOZErqd1JynQLiOGvM"
+        },
+        {
+            "name": "snapd",
+            "type": "snapd",
+            "default-channel": "latest/stable",
+            "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"
+        },
+        {
+            "default-channel": "24/stable",
+            "id": "ASctKBEHzVt3f1pbZLoekCvcigRjtuqw",
+            "name": "console-conf",
+            "presence": "optional",
+            "type": "app"
+        }
+    ]
+}

--- a/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson.model
+++ b/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson.model
@@ -1,0 +1,48 @@
+type: model
+authority-id: canonical
+series: 16
+brand-id: canonical
+model: ubuntu-core-24-tegra-jetson
+architecture: arm64
+base: core24
+grade: signed
+snaps:
+  -
+    default-channel: 24-jetson/stable
+    id: 9pjCtYlNoT9Fx6RiHMhhBoIG6ZYXBvJc
+    name: tegra
+    type: gadget
+  -
+    default-channel: 24-jetson/stable
+    id: Rjyoy6Zhe9mlkBQqmVzaUdPB2TblFSwV
+    name: tegra-kernel
+    type: kernel
+  -
+    default-channel: latest/stable
+    id: dwTAh7MZZ01zyriOZErqd1JynQLiOGvM
+    name: core24
+    type: base
+  -
+    default-channel: latest/stable
+    id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
+    name: snapd
+    type: snapd
+  -
+    default-channel: 24/stable
+    id: ASctKBEHzVt3f1pbZLoekCvcigRjtuqw
+    name: console-conf
+    presence: optional
+    type: app
+timestamp: 2026-07-10T09:28:47+00:00
+sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
+
+AcLBXAQAAQoABgUCalEuXAAKCRDgT5vottzAElhsD/9Yl+/tmpCTY2QIklSe+/AUqHjVV3WBrXHW
+Fd1Nyzno709qfLPMPFSpbA0Ryr/htI1+OKrC9diagDeWHPOujGVU5kUIp2nFlh6y07pgXhmzE4LT
+37GKsQCrhAfAgri2m4iOiKi7BClnoEKxMTy/DOFvwLj3+ULm16IeJgEc0qOBf5yNhH389I013tSs
+1AvmnDNR3qdOFOoYfgKzo8dpuRhUI+TBnvIyk6btzfsSzr8o3tgYAYOmBntVK2LE15DeKTtPj1FH
+tti2QEUOWtIn/vURcXDunejbi4KESQLtzSA30g5+O5Yh08jJJz183YYUoC9/Zh+Y5ZcBl5bUNrg/
+5VwlsMdEogPIWKQufpMrSNLhC4sZ5aQ1tc4WPqCpfravp+5tw0cJC4Td4LsruMo56lS5/t/I3rkA
+uwXO+WOZ9dyaPs+rrjmpdcWPTJYMSfKFEjQXKejC32c4bnfgF4WAn8SeOazJeb4xKNj/3GiaC2qD
+tSriY5y3BkZTFiXdSUixnafImRUdD2TD24ROaCmEG/PV5Vu01BOUXz6Nx507LjkXSH9VPzip2OHO
+AY8QpEbe0+yS7JUdM4zhQq8caYiYxwvDNqMnOPhJ9w7l3p7eAHOzeg49QHyBDc9p7dxzCyN42FQg
+xEw2eaT1myVvNObQZ5fFrHjnLr2A9NmqvCSENCWzqg==


### PR DESCRIPTION
Add stable and dangerous grade model definitions for stable, beta, candidate and edge.

The non-edge images can't be built yet as the kernel snap has not been published to all risks yet but this should soon be the case.