### PR TITLE
jetson: change UC24 model names

### DIFF
--- a/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson-beta.json
+++ b/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson-beta.json
@@ -1,7 +1,7 @@
 {
     "type": "model",
     "series": "16",
-    "model": "ubuntu-core-24-tegra-jetson",
+    "model": "ubuntu-core-24-tegra-jetson-beta",
     "architecture": "arm64",
     "authority-id": "canonical",
     "brand-id": "canonical",

--- a/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson-candidate.json
+++ b/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson-candidate.json
@@ -1,7 +1,7 @@
 {
     "type": "model",
     "series": "16",
-    "model": "ubuntu-core-24-tegra-jetson",
+    "model": "ubuntu-core-24-tegra-jetson-candidate",
     "architecture": "arm64",
     "authority-id": "canonical",
     "brand-id": "canonical",

--- a/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson-dangerous-beta.json
+++ b/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson-dangerous-beta.json
@@ -1,7 +1,7 @@
 {
     "type": "model",
     "series": "16",
-    "model": "ubuntu-core-24-tegra-jetson",
+    "model": "ubuntu-core-24-tegra-jetson-dangerous-beta",
     "architecture": "arm64",
     "authority-id": "canonical",
     "brand-id": "canonical",

--- a/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson-dangerous-candidate.json
+++ b/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson-dangerous-candidate.json
@@ -1,7 +1,7 @@
 {
     "type": "model",
     "series": "16",
-    "model": "ubuntu-core-24-tegra-jetson",
+    "model": "ubuntu-core-24-tegra-jetson-dangerous-candidate",
     "architecture": "arm64",
     "authority-id": "canonical",
     "brand-id": "canonical",

--- a/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson-dangerous-edge.json
+++ b/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson-dangerous-edge.json
@@ -1,7 +1,7 @@
 {
     "type": "model",
     "series": "16",
-    "model": "ubuntu-core-24-tegra-jetson",
+    "model": "ubuntu-core-24-tegra-jetson-dangerous-edge",
     "architecture": "arm64",
     "authority-id": "canonical",
     "brand-id": "canonical",

--- a/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson-dangerous.json
+++ b/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson-dangerous.json
@@ -1,7 +1,7 @@
 {
     "type": "model",
     "series": "16",
-    "model": "ubuntu-core-24-tegra-jetson",
+    "model": "ubuntu-core-24-tegra-jetson-dangerous",
     "architecture": "arm64",
     "authority-id": "canonical",
     "brand-id": "canonical",

--- a/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson-edge.json
+++ b/devices/nvidia/jetson/ubuntu-core-24-tegra-jetson-edge.json
@@ -1,7 +1,7 @@
 {
     "type": "model",
     "series": "16",
-    "model": "ubuntu-core-24-tegra-jetson",
+    "model": "ubuntu-core-24-tegra-jetson-edge",
     "architecture": "arm64",
     "authority-id": "canonical",
     "brand-id": "canonical",


### PR DESCRIPTION
Make every UC24 model name for nvidia jetson devices unique so they can be uploaded to the store correctly.