### PR TITLE
Add a classic model for arm64 (dangerous)

### DIFF
--- a/ubuntu-classic-2610-arm64-dangerous.json
+++ b/ubuntu-classic-2610-arm64-dangerous.json
@@ -1,0 +1,113 @@
+{
+    "type": "model",
+    "series": "16",
+    "authority-id": "canonical",
+    "brand-id": "canonical",
+    "model": "ubuntu-classic-2610-arm64-dangerous",
+    "architecture": "arm64",
+    "timestamp": "2026-08-19T07:39:04+00:00",
+    "base": "core24",
+    "grade": "dangerous",
+    "classic": "true",
+    "distribution": "ubuntu",
+    "snaps": [
+        {
+            "name": "pc",
+            "type": "gadget",
+            "default-channel": "classic-26.10/edge",
+            "id": "UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH"
+        },
+        {
+            "name": "pc-kernel",
+            "type": "kernel",
+            "default-channel": "26.10/edge",
+            "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza",
+            "components": {
+                "nvidia-590-uda-ko": {
+                    "presence": "optional"
+                },
+                "nvidia-590-uda-user": {
+                    "presence": "optional"
+                }
+            }
+        },
+        {
+            "name": "core24",
+            "type": "base",
+            "default-channel": "latest/edge",
+            "id": "dwTAh7MZZ01zyriOZErqd1JynQLiOGvM"
+        },
+        {
+            "name": "core26",
+            "type": "base",
+            "default-channel": "latest/edge",
+            "id": "cUqM61hRuZAJYmIS898Ux66VY61gBbZf"
+        },
+        {
+            "name": "snapd",
+            "type": "snapd",
+            "default-channel": "latest/edge",
+            "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"
+        },
+        {
+            "name": "bare",
+            "type": "base",
+            "default-channel": "latest/edge",
+            "id": "EISPgh06mRh1vordZY9OZ34QHdd7OrdR"
+        },
+        {
+            "name": "mesa-2404",
+            "type": "app",
+            "default-channel": "latest/edge",
+            "id": "HyhSEBPv3vHsW6uOHkQR384NgI7S6zpj"
+        },
+        {
+            "name": "firmware-updater",
+            "type": "app",
+            "default-channel": "1/edge",
+            "id": "EI0D1KHjP8XiwMZKqSjuh6W8zvcowUVP"
+        },
+        {
+            "name": "desktop-security-center",
+            "type": "app",
+            "default-channel": "1/edge",
+            "id": "FppXWunWzuRT2NUT9CwoBPNJNZBYOCk0"
+        },
+        {
+            "name": "prompting-client",
+            "type": "app",
+            "default-channel": "1/edge",
+            "id": "aoc5lfC8aUd2VL8VpvynUJJhGXp5K6Dj"
+        },
+        {
+            "name": "snap-store",
+            "type": "app",
+            "default-channel": "2/edge",
+            "id": "gjf3IPXoRiipCu9K0kVu52f0H56fIksg"
+        },
+        {
+            "name": "gtk-common-themes",
+            "type": "app",
+            "default-channel": "latest/edge",
+            "id": "jZLfBRzf1cYlYysIjD2bwSzNtngY0qit"
+        },
+        {
+            "name": "firefox",
+            "type": "app",
+            "default-channel": "latest/edge",
+            "id": "3wdHCAVyZEmYsCMFDE9qt92UV8rC8Wdk"
+        },
+        {
+            "name": "gnome-46-2404",
+            "type": "app",
+            "default-channel": "latest/edge",
+            "id": "ew7OxpbRTxfK7ImpIygRR85lkxvU7Pzt"
+        },
+        {
+            "name": "snapd-desktop-integration",
+            "type": "app",
+            "default-channel": "latest/edge",
+            "id": "IrwRHakqtzhFRHJOOPxKVPU0Kk7Erhcu"
+        }
+    ]
+}


### PR DESCRIPTION
This is almost of copypaste of the amd64 one, except for the arch, and the timestamp.

Note to the reviewer: the timestamp format I followed is from the [documentation](https://documentation.ubuntu.com/core/tutorials/build-your-first-image/sign-the-model/#update-the-timestamp) but it seems slightly different from what was in place:
`2026-05-06T11:17:20.0Z --> 2026-08-19T07:39:04+00:00`